### PR TITLE
Use the entire version string from meson.build in pkgver

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -52,7 +52,7 @@ prepare() {
 pkgver() {
   cd ${srcdir}/${_pkgname}
   printf "%s.r%s.%s" \
-    $(grep -ozP "(?s)^project\('gegl'.*?version: *'\K[\d.]*" meson.build|tr '\0' '\n') \
+    $(grep -ozP "(?s)^project\('gegl'.*?version: *'\K[^']*" meson.build|tr '\0' '\n') \
     $(git rev-list --count HEAD) \
     $(git rev-parse --short HEAD)
 }

--- a/PKGBUILD.in
+++ b/PKGBUILD.in
@@ -52,7 +52,7 @@ prepare() {
 pkgver() {
   cd ${srcdir}/${_pkgname}
   printf "%s.r%s.%s" \
-    $(grep -ozP "(?s)^project\('gegl'.*?version: *'\K[\d.]*" meson.build|tr '\0' '\n') \
+    $(grep -ozP "(?s)^project\('gegl'.*?version: *'\K[^']*" meson.build|tr '\0' '\n') \
     $(git rev-list --count HEAD) \
     $(git rev-parse --short HEAD)
 }


### PR DESCRIPTION
`pkgver` is currently outputting a wrong version number, `0..r10513.1794e20e8`, instead of `0.4.45.r10513.1794e20e8`.

This PR makes it matches the whole `version` string in `meson.build`, instead of matching the numbers and dots inside it, as that seems to be broken with GNU grep 3.10. Its [release notes](https://savannah.gnu.org/forum/forum.php?forum_id=10372) state:

> With -P, \d now matches only ASCII digits, regardless of PCRE
> options/modes. The changes in grep-3.9 to make \b and \w work
> properly had the undesirable side effect of making \d also match
> e.g., the Arabic digits: ٠١٢٣٤٥٦٧٨٩.  With grep-3.9, -P '\d+'
> would match that ten-digit (20-byte) string. Now, to match such
> a digit, you would use \p{Nd}. Similarly, \D is now mapped to [^0-9].
> [bug introduced in grep 3.9]

As hinted by the release notes, replacing `\d` with `\p{nD}` also seems to fix it, but I find this method simpler.